### PR TITLE
feat: Convert auth controller responses to concrete types

### DIFF
--- a/SWAGGER-TO-MARKDOWN.md
+++ b/SWAGGER-TO-MARKDOWN.md
@@ -25,12 +25,12 @@ Send reset code for password reset
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 200  | OK                    | object |
-| 400  | Bad Request           | object |
-| 401  | Unauthorized          | object |
-| 500  | Internal Server Error | object |
+| Code | Description           | Schema                                                          |
+|------|-----------------------|-----------------------------------------------------------------|
+| 200  | OK                    | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 401  | Unauthorized          | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
 
 ### /auth/github/callback
 
@@ -49,13 +49,14 @@ Register a new user through GitHub
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 201  | Created               | object |
-| 400  | Bad Request           | object |
-| 409  | Conflict              | object |
-| 500  | Internal Server Error | object |
-| 502  | Bad Gateway           | object |
+| Code | Description           | Schema                                                                |
+|------|-----------------------|-----------------------------------------------------------------------|
+| 200  | OK                    | [models.AccessCodeResponseWrapper](#models.AccessCodeResponseWrapper) |
+| 201  | Created               | [models.AccessCodeResponseWrapper](#models.AccessCodeResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 409  | Conflict              | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 502  | Bad Gateway           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
 
 ### /auth/github/clientid
 
@@ -67,10 +68,10 @@ Get GitHub Client ID
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 200  | OK                    | object |
-| 500  | Internal Server Error | object |
+| Code | Description           | Schema                                                                        |
+|------|-----------------------|-------------------------------------------------------------------------------|
+| 200  | OK                    | [models.GitHubClientIdResponseWrapper](#models.GitHubClientIdResponseWrapper) |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)                   |
 
 ### /auth/login
 
@@ -88,12 +89,12 @@ Sign in a user
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 200  | OK                    | object |
-| 400  | Bad Request           | object |
-| 409  | Conflict              | object |
-| 500  | Internal Server Error | object |
+| Code | Description           | Schema                                                                |
+|------|-----------------------|-----------------------------------------------------------------------|
+| 200  | OK                    | [models.AccessCodeResponseWrapper](#models.AccessCodeResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 409  | Conflict              | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
 
 ### /auth/logout
 
@@ -105,9 +106,9 @@ Log out a user
 
 ##### Responses
 
-| Code | Description | Schema |
-|------|-------------|--------|
-| 200  | OK          | object |
+| Code | Description | Schema                                                          |
+|------|-------------|-----------------------------------------------------------------|
+| 200  | OK          | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
 
 ### /auth/refresh
 
@@ -119,11 +120,11 @@ Refresh access token with refresh token
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 200  | OK                    | object |
-| 403  | Forbidden             | object |
-| 500  | Internal Server Error | object |
+| Code | Description           | Schema                                                                |
+|------|-----------------------|-----------------------------------------------------------------------|
+| 200  | OK                    | [models.AccessCodeResponseWrapper](#models.AccessCodeResponseWrapper) |
+| 403  | Forbidden             | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)           |
 
 ### /auth/register
 
@@ -141,13 +142,13 @@ Register a new user
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 201  | Created               | object |
-| 400  | Bad Request           | object |
-| 409  | Conflict              | object |
-| 500  | Internal Server Error | object |
-| 502  | Bad Gateway           | object |
+| Code | Description           | Schema                                                          |
+|------|-----------------------|-----------------------------------------------------------------|
+| 201  | Created               | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 409  | Conflict              | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 502  | Bad Gateway           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
 
 ### /auth/resendverificationemail
 
@@ -165,12 +166,12 @@ Resend verification email
 
 ##### Responses
 
-| Code | Description           | Schema |
-|------|-----------------------|--------|
-| 200  | OK                    | object |
-| 400  | Bad Request           | object |
-| 409  | Conflict              | object |
-| 500  | Internal Server Error | object |
+| Code | Description           | Schema                                                          |
+|------|-----------------------|-----------------------------------------------------------------|
+| 200  | OK                    | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 409  | Conflict              | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
 
 ### /auth/resetpassword
 
@@ -190,10 +191,11 @@ Reset password
 
 ##### Responses
 
-| Code | Description | Schema |
-|------|-------------|--------|
-| 200  | OK          | object |
-| 400  | Bad Request | object |
+| Code | Description           | Schema                                                          |
+|------|-----------------------|-----------------------------------------------------------------|
+| 200  | OK                    | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
+| 400  | Bad Request           | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 500  | Internal Server Error | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
 
 ### /auth/usernameavailable/{username}
 
@@ -211,9 +213,9 @@ Check if username is available
 
 ##### Responses
 
-| Code | Description | Schema |
-|------|-------------|--------|
-| 200  | OK          | object |
+| Code | Description | Schema                                                          |
+|------|-------------|-----------------------------------------------------------------|
+| 200  | OK          | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
 
 ### /auth/verifyemail
 
@@ -232,11 +234,11 @@ Verify users email address
 
 ##### Responses
 
-| Code | Description | Schema |
-|------|-------------|--------|
-| 200  | OK          | object |
-| 400  | Bad Request | object |
-| 409  | Conflict    | object |
+| Code | Description | Schema                                                          |
+|------|-------------|-----------------------------------------------------------------|
+| 200  | OK          | [models.SuccessResponseWrapper](#models.SuccessResponseWrapper) |
+| 400  | Bad Request | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
+| 409  | Conflict    | [models.ErrorResponseWrapper](#models.ErrorResponseWrapper)     |
 
 ### /gists/{gistId}
 
@@ -680,6 +682,18 @@ Unfollow a user
 
 ### Models
 
+#### models.AccessCodeResponse
+
+| Name        | Type   | Description | Required |
+|-------------|--------|-------------|----------|
+| access_code | string |             | No       |
+
+#### models.AccessCodeResponseWrapper
+
+| Name        | Type                                                    | Description | Required |
+|-------------|---------------------------------------------------------|-------------|----------|
+| access_code | [models.AccessCodeResponse](#models.AccessCodeResponse) |             | No       |
+
 #### models.CommentOnGistRequest
 
 | Name    | Type   | Description | Required |
@@ -696,11 +710,36 @@ Unfollow a user
 | private | boolean |             | No       |
 | title   | string  |             | Yes      |
 
+#### models.ErrorResponse
+
+| Name        | Type    | Description | Required |
+|-------------|---------|-------------|----------|
+| message     | string  |             | No       |
+| status_code | integer |             | No       |
+
+#### models.ErrorResponseWrapper
+
+| Name  | Type                                          | Description | Required |
+|-------|-----------------------------------------------|-------------|----------|
+| error | [models.ErrorResponse](#models.ErrorResponse) |             | No       |
+
 #### models.ForgotPasswordInput
 
 | Name  | Type   | Description | Required |
 |-------|--------|-------------|----------|
 | email | string |             | Yes      |
+
+#### models.GitHubClientIdResponse
+
+| Name      | Type   | Description | Required |
+|-----------|--------|-------------|----------|
+| client_id | string |             | No       |
+
+#### models.GitHubClientIdResponseWrapper
+
+| Name             | Type                                                            | Description | Required |
+|------------------|-----------------------------------------------------------------|-------------|----------|
+| github_client_id | [models.GitHubClientIdResponse](#models.GitHubClientIdResponse) |             | No       |
 
 #### models.ResendVerificationEmailInput
 
@@ -732,6 +771,19 @@ Unfollow a user
 | password        | string |             | Yes      |
 | passwordConfirm | string |             | Yes      |
 | username        | string |             | Yes      |
+
+#### models.SuccessResponse
+
+| Name        | Type    | Description | Required |
+|-------------|---------|-------------|----------|
+| message     | string  |             | No       |
+| status_code | integer |             | No       |
+
+#### models.SuccessResponseWrapper
+
+| Name    | Type                                              | Description | Required |
+|---------|---------------------------------------------------|-------------|----------|
+| success | [models.SuccessResponse](#models.SuccessResponse) |             | No       |
 
 #### models.UpdateGistRequest
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -43,37 +43,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -104,49 +92,40 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
+                        }
+                    },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -165,19 +144,13 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.GitHubClientIdResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -210,37 +183,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -259,10 +220,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     }
                 }
@@ -281,28 +239,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -335,46 +284,31 @@ const docTemplate = `{
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -407,37 +341,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -484,19 +406,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -524,10 +446,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     }
                 }
@@ -562,28 +481,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -1496,6 +1406,22 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "models.AccessCodeResponse": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.AccessCodeResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "$ref": "#/definitions/models.AccessCodeResponse"
+                }
+            }
+        },
         "models.CommentOnGistRequest": {
             "type": "object",
             "required": [
@@ -1533,6 +1459,25 @@ const docTemplate = `{
                 }
             }
         },
+        "models.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.ErrorResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/models.ErrorResponse"
+                }
+            }
+        },
         "models.ForgotPasswordInput": {
             "type": "object",
             "required": [
@@ -1541,6 +1486,22 @@ const docTemplate = `{
             "properties": {
                 "email": {
                     "type": "string"
+                }
+            }
+        },
+        "models.GitHubClientIdResponse": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.GitHubClientIdResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "github_client_id": {
+                    "$ref": "#/definitions/models.GitHubClientIdResponse"
                 }
             }
         },
@@ -1616,6 +1577,25 @@ const docTemplate = `{
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "models.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.SuccessResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "success": {
+                    "$ref": "#/definitions/models.SuccessResponse"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -35,37 +35,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -96,49 +84,40 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
+                        }
+                    },
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -157,19 +136,13 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.GitHubClientIdResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -202,37 +175,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -251,10 +212,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     }
                 }
@@ -273,28 +231,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.AccessCodeResponseWrapper"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -327,46 +276,31 @@
                     "201": {
                         "description": "Created",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -399,37 +333,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -476,19 +398,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -516,10 +438,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     }
                 }
@@ -554,28 +473,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.SuccessResponseWrapper"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     },
                     "409": {
                         "description": "Conflict",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/models.ErrorResponseWrapper"
                         }
                     }
                 }
@@ -1488,6 +1398,22 @@
         }
     },
     "definitions": {
+        "models.AccessCodeResponse": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.AccessCodeResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "access_code": {
+                    "$ref": "#/definitions/models.AccessCodeResponse"
+                }
+            }
+        },
         "models.CommentOnGistRequest": {
             "type": "object",
             "required": [
@@ -1525,6 +1451,25 @@
                 }
             }
         },
+        "models.ErrorResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.ErrorResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "error": {
+                    "$ref": "#/definitions/models.ErrorResponse"
+                }
+            }
+        },
         "models.ForgotPasswordInput": {
             "type": "object",
             "required": [
@@ -1533,6 +1478,22 @@
             "properties": {
                 "email": {
                     "type": "string"
+                }
+            }
+        },
+        "models.GitHubClientIdResponse": {
+            "type": "object",
+            "properties": {
+                "client_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.GitHubClientIdResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "github_client_id": {
+                    "$ref": "#/definitions/models.GitHubClientIdResponse"
                 }
             }
         },
@@ -1608,6 +1569,25 @@
                 },
                 "username": {
                     "type": "string"
+                }
+            }
+        },
+        "models.SuccessResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "status_code": {
+                    "type": "integer"
+                }
+            }
+        },
+        "models.SuccessResponseWrapper": {
+            "type": "object",
+            "properties": {
+                "success": {
+                    "$ref": "#/definitions/models.SuccessResponse"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,15 @@
 basePath: /api/
 definitions:
+  models.AccessCodeResponse:
+    properties:
+      access_code:
+        type: string
+    type: object
+  models.AccessCodeResponseWrapper:
+    properties:
+      access_code:
+        $ref: '#/definitions/models.AccessCodeResponse'
+    type: object
   models.CommentOnGistRequest:
     properties:
       content:
@@ -25,12 +35,34 @@ definitions:
     - name
     - title
     type: object
+  models.ErrorResponse:
+    properties:
+      message:
+        type: string
+      status_code:
+        type: integer
+    type: object
+  models.ErrorResponseWrapper:
+    properties:
+      error:
+        $ref: '#/definitions/models.ErrorResponse'
+    type: object
   models.ForgotPasswordInput:
     properties:
       email:
         type: string
     required:
     - email
+    type: object
+  models.GitHubClientIdResponse:
+    properties:
+      client_id:
+        type: string
+    type: object
+  models.GitHubClientIdResponseWrapper:
+    properties:
+      github_client_id:
+        $ref: '#/definitions/models.GitHubClientIdResponse'
     type: object
   models.ResendVerificationEmailInput:
     properties:
@@ -83,6 +115,18 @@ definitions:
     - password
     - passwordConfirm
     - username
+    type: object
+  models.SuccessResponse:
+    properties:
+      message:
+        type: string
+      status_code:
+        type: integer
+    type: object
+  models.SuccessResponseWrapper:
+    properties:
+      success:
+        $ref: '#/definitions/models.SuccessResponse'
     type: object
   models.UpdateGistRequest:
     properties:
@@ -137,27 +181,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "401":
           description: Unauthorized
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Send reset code for password reset
       tags:
       - Authentication
@@ -176,36 +212,30 @@ paths:
       produces:
       - application/json
       responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.AccessCodeResponseWrapper'
         "201":
           description: Created
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.AccessCodeResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "409":
           description: Conflict
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Register a new user through GitHub
       tags:
       - Authentication
@@ -217,15 +247,11 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.GitHubClientIdResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Get GitHub Client ID
       tags:
       - Authentication
@@ -246,27 +272,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.AccessCodeResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "409":
           description: Conflict
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Sign in a user
       tags:
       - Authentication
@@ -278,9 +296,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
       summary: Log out a user
       tags:
       - Authentication
@@ -292,21 +308,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.AccessCodeResponseWrapper'
         "403":
           description: Forbidden
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Refresh access token with refresh token
       tags:
       - Authentication
@@ -327,33 +337,23 @@ paths:
         "201":
           description: Created
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "409":
           description: Conflict
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "502":
           description: Bad Gateway
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Register a new user
       tags:
       - Authentication
@@ -374,27 +374,19 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "409":
           description: Conflict
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "500":
           description: Internal Server Error
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Resend verification email
       tags:
       - Authentication
@@ -425,15 +417,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Reset password
       tags:
       - Authentication
@@ -451,9 +443,7 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
       summary: Check if username is available
       tags:
       - Authentication
@@ -476,21 +466,15 @@ paths:
         "200":
           description: OK
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.SuccessResponseWrapper'
         "400":
           description: Bad Request
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
         "409":
           description: Conflict
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/models.ErrorResponseWrapper'
       summary: Verify users email address
       tags:
       - Authentication

--- a/models/helper_non_db_model.go
+++ b/models/helper_non_db_model.go
@@ -80,3 +80,21 @@ type UpdateGistRequest struct {
 	Title   string `json:"title"`
 	GistId  string `json:"gistId" binding:"required"`
 }
+
+type ErrorResponse struct {
+	StatusCode int    `json:"status_code"`
+	Message    string `json:"message"`
+}
+
+type SuccessResponse struct {
+	StatusCode int    `json:"status_code"`
+	Message    string `json:"message"`
+}
+
+type GitHubClientIdResponse struct {
+	ClientId string `json:"client_id"`
+}
+
+type AccessCodeResponse struct {
+	AccessCode string `json:"access_code"`
+}

--- a/models/json_response_structs.go
+++ b/models/json_response_structs.go
@@ -1,0 +1,17 @@
+package models
+
+type ErrorResponseWrapper struct {
+	Error ErrorResponse `json:"error"`
+}
+
+type SuccessResponseWrapper struct {
+	Success SuccessResponse `json:"success"`
+}
+
+type GitHubClientIdResponseWrapper struct {
+	GitHubClientId GitHubClientIdResponse `json:"github_client_id"`
+}
+
+type AccessCodeResponseWrapper struct {
+	AccessCode AccessCodeResponse `json:"access_code"`
+}

--- a/utils/rest.go
+++ b/utils/rest.go
@@ -3,9 +3,36 @@ package utils
 import (
 	"net/http"
 
+	"github.com/Vyom-Yadav/GitHub-Gist-Clone-Backend/models"
 	"github.com/gin-gonic/gin"
 )
 
 func SomethingBadHappened(ctx *gin.Context) {
-	ctx.JSON(http.StatusInternalServerError, gin.H{"status": "fail", "message": "Something bad happened"})
+	NewErrorResponse(ctx, http.StatusInternalServerError, "Something bad happened")
+}
+
+func NewErrorResponse(ctx *gin.Context, statusCode int, message string) {
+	ctx.JSON(statusCode, models.ErrorResponseWrapper{
+		Error: models.ErrorResponse{
+			Message:    message,
+			StatusCode: statusCode,
+		},
+	})
+}
+
+func NewSuccessResponse(ctx *gin.Context, statusCode int, message string) {
+	ctx.JSON(statusCode, models.SuccessResponseWrapper{
+		Success: models.SuccessResponse{
+			Message:    message,
+			StatusCode: statusCode,
+		},
+	})
+}
+
+func NewAccessCodeResponse(ctx *gin.Context, statusCode int, accessCode string) {
+	ctx.JSON(statusCode, models.AccessCodeResponseWrapper{
+		AccessCode: models.AccessCodeResponse{
+			AccessCode: accessCode,
+		},
+	})
 }


### PR DESCRIPTION
- Changed response types from `map[string]any` to concrete types.
- Updated swagger documentation